### PR TITLE
[WIP] GDPR export data

### DIFF
--- a/classes/hooks/synchronization/SingleUser.php
+++ b/classes/hooks/synchronization/SingleUser.php
@@ -246,4 +246,20 @@ class HooksSynchronizationSingleUser extends HooksSynchronizationSynchronization
         }
         return true;
     }
+
+    /**
+     * Get Contact information by email
+     * @param string $email
+     * @return object
+     */
+    public function getCustomerByEmail($email)
+    {
+        $apiOverlay = $this->getApiOverlay();
+        $contact= $apiOverlay->getContactByEmail($email);
+        if (!$contact) {
+            return false;
+        }
+        return $contact;
+    }
+
 }

--- a/mailjet.php
+++ b/mailjet.php
@@ -1963,4 +1963,41 @@ class Mailjet extends Module
     {
         return md5($this->account->TOKEN);
     }
+
+    public function hookActionExportGDPRData($customer)
+    {
+        if (!Tools::isEmpty($customer['email']) && Validate::isEmail($customer['email'])) {
+
+            if (!$customer) {
+                return false;
+            }
+
+            $initialSynchronization = new HooksSynchronizationSingleUser(MailjetTemplate::getApi());
+            $customerMailJet = $initialSynchronization->getCustomerByEmail($customer['email']);
+            
+            if( !$customerMailJet || empty($customerMailJet) ) {
+                return json_encode($this->l('Mailjet : Unable to export customer using email.'));
+            }
+
+            $dateAdd = new DateTime($customerMailJet->Data[0]->CreatedAt);
+            $dateLastActivity = new DateTime($customerMailJet->Data[0]->LastActivityAt);      
+
+            $return[] = [
+                $this->l('Email') => $customerMailJet->Data[0]->Email,
+                $this->l('Date add') => $dateAdd->format('Y-m-d H:i:s'),
+                $this->l('Newsletters sended') => $customerMailJet->Data[0]->DeliveredCount,
+                $this->l('Last Activity') =>  $dateLastActivity->format('Y-m-d H:i:s'), 
+            ];
+
+            return json_encode($return);
+
+        }
+    }
+
+    public function hookRegisterGDPRConsent($param)
+    {
+
+        return;
+    }
+
 }


### PR DESCRIPTION
If you follow this way 

http://build.prestashop.com/howtos/module/how-to-make-your-module-compliant-with-prestashop-official-gdpr-compliance-module/

My PR give on an export data : 

![mail-jet-gdpr](https://user-images.githubusercontent.com/5064590/41913777-83ea33d6-7951-11e8-8732-8d0136994f9d.png)


The actionDeleteGDPRCustomer hook is not needed because there are already actions on other hook