### PR TITLE
Secure bundlejs_prestashop.php that can be called directly

### DIFF
--- a/ajax/bundlejs_prestashop.php
+++ b/ajax/bundlejs_prestashop.php
@@ -29,7 +29,7 @@ include_once(_PS_ROOT_DIR_ . '/init.php');
 include_once(_PS_MODULE_DIR_ . 'mailjet/mailjet.php');
 $return = '';
 
-if (Tools::getValue('token') != Configuration::get('SEGMENT_CUSTOMER_TOKEN')) {
+if (Tools::getValue('token') != Configuration::get('SEGMENT_CUSTOMER_TOKEN') OR !Configuration::get('SEGMENT_CUSTOMER_TOKEN')) {
     exit();
 }
 


### PR DESCRIPTION
bundlejs_prestashop.php can be called without token when module is uninstalled.
This can expose datas like manufacturer list like this : /modules/mailjet/ajax/bundlejs_prestashop.php?action=manufacturer&name=%

If the module is not installed, the SEGMENT_CUSTOMER_TOKEN is not set and the token check is by passed.

My PR check that the token is not empty.